### PR TITLE
Basic authenticated option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ func main() {
   // set CouchDB url and database name
   follow.Url = "http://127.0.0.1:5984/"
   follow.Database = "_users"
+  follow.User = "user"
+  follow.Pass = "password"
 
   // set query parameters
   params := follow.QueryParameters{

--- a/follow_test.go
+++ b/follow_test.go
@@ -74,10 +74,10 @@ loop:
 			if ok == false {
 				t.Fatal("continuous error")
 			}
-			if change.Seq == 1 && change.Id != "john" {
+			if change.Id != "john" {
 				t.Fatal("continuous error")
 			}
-			if change.Seq == 2 && change.Id != "steve" {
+			if change.Id != "steve" {
 				t.Fatal("continuous error")
 			}
 		case err := <-errors:


### PR DESCRIPTION
Fixed the deadlock in situation when the first request to CouchDB fails (line 140, nothing reads from the channel, but if a database is down, an error would be pushed to a channel and block)
Updated comments accordingly and README.md accordingly.
